### PR TITLE
Fix errors in ElementsBase.

### DIFF
--- a/lib/elements/ElementsBase.ts
+++ b/lib/elements/ElementsBase.ts
@@ -180,8 +180,8 @@ export class ElementsBase extends AssetBase implements IElements {
 
 		for (const name in this._customAttributes) {
 			this._customAttributes[name].dispose();
-			delete this._customAttributes;
 		}
+		delete this._customAttributes;
 	}
 
 	/**
@@ -239,10 +239,12 @@ export class ElementsBase extends AssetBase implements IElements {
 			}
 
 			this._customAttributes[name].set(values, offset);
-		} else if (this._customAttributes[name]) {
-			this.clearVertices(this._customAttributes[name]);
-			this._customAttributesNames.splice(this._customAttributesNames.indexOf(name), 1);
-			delete this._customAttributes[name];
+		} else {
+			if (this._customAttributes[name]) {
+				this.clearVertices(this._customAttributes[name]);
+				this._customAttributesNames.splice(this._customAttributesNames.indexOf(name), 1);
+				delete this._customAttributes[name];
+			}
 			return;
 		}
 


### PR DESCRIPTION
- In `dispose()`, don't delete `_customAttributes` until finished iterating through it.
- In `setCustomAttributes()`, when `_customAttributes[name]` doesn't exist, make sure to return, or else the code after will attempt to access `_customAttributes[name].id`.